### PR TITLE
Tiny last step

### DIFF
--- a/303-occupancy-ottawa/code/change-point.stan
+++ b/303-occupancy-ottawa/code/change-point.stan
@@ -1,11 +1,13 @@
 
 data {
 
-    int  <lower=1> M;                   // number of jurisdictions
-    int  <lower=1> N0;                  // number of days for which to impute infections
-    int  <lower=1> N2;                  // days of observed data + # of days to forecast
-    real <lower=0> log_max_step_large;  // natural logarithm of absolute value of maximum   upward step size
-    real <lower=0> log_max_step_small;  // natural logarithm of absolute value of maximum downward step size
+    int  <lower=1> M;   // number of jurisdictions
+    int  <lower=1> N0;  // number of days for which to impute infections
+    int  <lower=1> N2;  // days of observed data + # of days to forecast
+
+    real <lower=0> log_max_step_large;
+    real <lower=0> log_max_step_small;
+    real <lower=0> log_max_step_four;
 
     int minChgPt1[M];
     int maxChgPt1[M];
@@ -44,10 +46,10 @@ parameters {
     real <lower=0,upper=1> Uchg3[M];
     real <lower=0,upper=1> Uchg4[M];
 
-    real <lower = -log_max_step_large, upper = 0>                  step1[M];
-    real <lower = -log_max_step_small, upper = log_max_step_small> step2[M];
-    real <lower = -log_max_step_small, upper = log_max_step_small> step3[M];
-    real <lower = -log_max_step_small, upper = log_max_step_small> step4[M];
+    real < lower = -log_max_step_large , upper = 0                  > step1[M];
+    real < lower =  0                  , upper = log_max_step_small > step2[M];
+    real < lower = -log_max_step_small , upper = 0                  > step3[M];
+    real < lower = -log_max_step_four  , upper = log_max_step_four  > step4[M];
 
     real <lower=0> phi;
 
@@ -124,9 +126,9 @@ model {
         Uchg4[m] ~ uniform(0,1);
 
         step1[m] ~ uniform( -log_max_step_large , 0                  );
-        step2[m] ~ uniform( -log_max_step_small , log_max_step_small );
-        step3[m] ~ uniform( -log_max_step_small , log_max_step_small );
-        step4[m] ~ uniform( -log_max_step_small , log_max_step_small );
+        step2[m] ~ uniform(  0                  , log_max_step_small );
+        step3[m] ~ uniform( -log_max_step_small , 0                  );
+        step4[m] ~ uniform( -log_max_step_four  , log_max_step_four  );
 
     }
 

--- a/303-occupancy-ottawa/code/visualizeModel-change-point.R
+++ b/303-occupancy-ottawa/code/visualizeModel-change-point.R
@@ -38,10 +38,10 @@ visualizeModel.change.point <- function(
         list.input = list.input
         );
 
-    plot.forecast(
-        list.input      = list.input,
-        forecast.window = forecast.window
-        );
+    # plot.forecast(
+    #     list.input      = list.input,
+    #     forecast.window = forecast.window
+    #     );
 
     ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
     cat(paste0("\n",thisFunctionName,"() quits."));

--- a/303-occupancy-ottawa/code/wrapper-stan-change-point.R
+++ b/303-occupancy-ottawa/code/wrapper-stan-change-point.R
@@ -122,6 +122,7 @@ wrapper.stan_inner <- function(
     stan_data <- list(
         log_max_step_large = log(4.0),
         log_max_step_small = log(1.5),
+        log_max_step_four  = log(1.1),
         M                  = length(jurisdictions),
         N                  = NULL,
         x1                 = poly(1:N2,2)[,1],
@@ -296,9 +297,9 @@ wrapper.stan_inner <- function(
                 Uchg4 = runif(length(jurisdictions), min = 0, max = 1),
                #Uchg5 = runif(length(jurisdictions), min = 0, max = 1),
                 step1 = runif(length(jurisdictions), min = -stan_data[["log_max_step_large"]], max = 0                                ),
-                step2 = runif(length(jurisdictions), min = -stan_data[["log_max_step_small"]], max = stan_data[["log_max_step_small"]]),
-                step3 = runif(length(jurisdictions), min = -stan_data[["log_max_step_small"]], max = stan_data[["log_max_step_small"]]),
-                step4 = runif(length(jurisdictions), min = -stan_data[["log_max_step_small"]], max = stan_data[["log_max_step_small"]])
+                step2 = runif(length(jurisdictions), min =  0,                                 max = stan_data[["log_max_step_small"]]),
+                step3 = runif(length(jurisdictions), min = -stan_data[["log_max_step_small"]], max = 0                                ),
+                step4 = runif(length(jurisdictions), min = -stan_data[["log_max_step_four"]],  max = stan_data[["log_max_step_four" ]])
               #,step5 = runif(length(jurisdictions), min = -stan_data[["log_max_step_small"]], max = stan_data[["log_max_step_small"]])
                 )
             }

--- a/303-occupancy-ottawa/code/wrapper-stan-length-of-stay.R
+++ b/303-occupancy-ottawa/code/wrapper-stan-length-of-stay.R
@@ -281,7 +281,7 @@ wrapper.stan.length.of.stay_is.not.stuck <- function(
         temp.chain.ID   <- DF.chains[row.index,'chain.ID'];
         is.selected.row <- (DF.samples[,'chain.ID'] == temp.chain.ID);
         temp.vector     <- DF.samples[is.selected.row,'value'];
-        DF.chains[row.index,'chain.var'] <- stats::sd(x = temp.vector, na.rm = TRUE);
+        DF.chains[row.index,'chain.var'] <- stats::var(x = temp.vector, na.rm = TRUE);
         }
 
     DF.chains[,'normalized.chain.var'] <- DF.chains[,'chain.var'] / sum(DF.chains[,'chain.var']);

--- a/303-occupancy-ottawa/code/wrapper-stan-length-of-stay.R
+++ b/303-occupancy-ottawa/code/wrapper-stan-length-of-stay.R
@@ -261,12 +261,13 @@ wrapper.stan.length.of.stay_is.not.stuck <- function(
     require(dplyr);
 
     ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
-    chain.size <- (n.iterations - n.warmup) / period.thinning;
+    # chain.size <- (n.iterations - n.warmup) / period.thinning;
 
     ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
     DF.samples <- data.frame(
         index    = seq(1,length(input.vector)),
-        chain.ID = rep(x = seq(1,n.chains), each = chain.size),
+      # chain.ID = rep(x = seq(1,n.chains), each = chain.size),
+        chain.ID = rep(x = seq(1,n.chains), each = length(input.vector) / n.chains),
         value    = input.vector
         );
 

--- a/303-occupancy-ottawa/code/wrapper-stan-length-of-stay.R
+++ b/303-occupancy-ottawa/code/wrapper-stan-length-of-stay.R
@@ -57,6 +57,16 @@ wrapper.stan.length.of.stay <- function(
     #     period.thinning       = period.thinning
     #     );
 
+    list.output <- wrapper.stan.length.of.stay_patch(
+        list.input            = list.output,
+        DF.input              = DF.input,
+        threshold.stuck.chain = threshold.stuck.chain,
+        n.chains              = n.chains,
+        n.iterations          = n.iterations,
+        n.warmup              = n.warmup,
+        period.thinning       = period.thinning
+        );
+
     ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
     cat(paste0("\n",thisFunctionName,"() quits."));
     cat("\n### ~~~~~~~~~~~~~~~~~~~~ ###\n");
@@ -66,6 +76,40 @@ wrapper.stan.length.of.stay <- function(
 
 ##################################################
 wrapper.stan.length.of.stay_patch <- function(
+    list.input            = NULL,
+    DF.input              = NULL,
+    threshold.stuck.chain = NULL,
+    n.chains              = NULL,
+    n.iterations          = NULL,
+    n.warmup              = NULL,
+    period.thinning       = NULL
+    ) {
+
+    list.output <- list.input;
+
+    if( threshold.stuck.chain != list.input[['threshold.stuck.chain']] ) {
+        list.input[['threshold.stuck.chain']] <- threshold.stuck.chain;
+        jurisdictions <- list.input[['jurisdictions']];
+        is.not.stuck <- list();
+        for( temp.index in 1:length(jurisdictions) ) {
+            jurisdiction <- jurisdictions[temp.index];
+            is.not.stuck[[jurisdiction]] <- wrapper.stan.length.of.stay_is.not.stuck(
+                threshold.stuck.chain = threshold.stuck.chain,
+                input.vector          = list.input[['posterior.samples']][['alpha']][,temp.index],
+                n.chains              = n.chains,
+                n.iterations          = n.iterations,
+                n.warmup              = n.warmup,
+                period.thinning       = period.thinning
+                );
+            }
+        list.output[['is.not.stuck']] <- is.not.stuck;
+        }
+
+    return( list.output );
+
+    }
+
+wrapper.stan.length.of.stay_patch_DELETEME <- function(
     list.input            = NULL,
     DF.input              = NULL,
     threshold.stuck.chain = NULL,
@@ -261,12 +305,8 @@ wrapper.stan.length.of.stay_is.not.stuck <- function(
     require(dplyr);
 
     ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
-    # chain.size <- (n.iterations - n.warmup) / period.thinning;
-
-    ### ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ###
     DF.samples <- data.frame(
         index    = seq(1,length(input.vector)),
-      # chain.ID = rep(x = seq(1,n.chains), each = chain.size),
         chain.ID = rep(x = seq(1,n.chains), each = length(input.vector) / n.chains),
         value    = input.vector
         );


### PR DESCRIPTION
In 303-occupancy-ottawa:

-  added restrictions to prior distributions on:
    -  the change direction at Change Point 2 must be upward,
    -  the change direction at Change Font 3 must be downward,
    -  the step size at Change Point 4 is now restricted between -log(1.1) and log(1.1)

-  improved wrapper.stan.length.of.stay_is.not.stuck()

-  Reactivated wrapper.stan.length.of.stay_patch():
    -  if the Stan model already exists on file, but the call to wrapper.stan.length.of.stay() was made with a threshold.stuck.chain value distinct from that of the preexisting Stan model, then wrapper.stan.length.of.stay_is.not.stuck() will be run with the new value for threshold.stuck.chain in order to override the preexisting value.

